### PR TITLE
Feature 122

### DIFF
--- a/src/loaders/automation-slot-times.ts
+++ b/src/loaders/automation-slot-times.ts
@@ -1,0 +1,41 @@
+import { ServiceSetting } from "../models/service-setting";
+import { addDay } from "../utils/date-utils";
+
+const automationSlotTimesJob = async (container, options) => {
+    const eventBus_ = container.resolve("eventBusService");
+    const setting_ = container.resolve("serviceSettingService");
+
+    // do cronjob everyhour
+    eventBus_.createCronJob("automation-slot-times", {}, "0 * * * *", async () => {
+        const setting = {}
+        const getSetting: ServiceSetting[] = await setting_.all({}, {})
+
+        for (const settingData of Object.values(getSetting)) {
+            setting[settingData.option] = settingData.value
+        }
+        
+        const today = new Date()
+        const todayIndex = today.getDay()
+        const todayTime = today.getHours()
+        const isAutomationSlotEnable = (setting['automation_slot'] === 'true')
+        const automationSlotW = setting['automation_slot_w']
+        const automationSlotT = parseInt(setting['automation_slot_t'])
+        const automationSlotD = setting['automation_slot_d']
+
+        // check if automation enabled
+        if (!isAutomationSlotEnable) return false
+
+        // check date
+        if (todayIndex != automationSlotD) return false
+
+        // check time
+        if (todayTime != automationSlotT) return false
+
+        // calculation today + (7 * automation_slot_w)
+        const maxReleased = addDay(today, 7 * automationSlotW)
+
+        await setting_.set('automation_max_slot_date_time', maxReleased)
+    })
+}
+
+export default automationSlotTimesJob;


### PR DESCRIPTION
Automatic release of available slots with configuration via service setting

Note: Need add this to medusa-config.js
```
resolve: `@ai-ecom/medusa-plugin-service`,
options: {
    settings: { // default service setting data if there no data in service setting for automation
        automation_slot: false, // toggle enable
        automation_slot_w: "4", // 4 week
        automation_slot_d: "1", // 0 = sunday, 6 = saturday
        automation_slot_t: "1", // clock in hour 0 - 23
        automation_max_slot_date_time: "2023-01-01T00:00:00.000Z"
    }
}
```